### PR TITLE
fix: remove rouge for deploy

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -14,4 +14,3 @@
  *= require_self
  */
 
-@import 'rouge';


### PR DESCRIPTION
部署時發現這裡會出現錯誤，說找不到 rouge，node modules 裡面也沒有叫做 rouge 的資料夾，發現拿掉這句 highlight 也不會不見，所以為了部署順利，先將這句拿掉