### PR TITLE
fix: change the way we use figaro env

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -260,7 +260,7 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
-  config.omniauth :github, ENV["GITHUB_CLIENT_ID"], ENV["GITHUB_CLIENT_SECERT"], :scope => 'user,public_repo'
+  config.omniauth :github, Figaro.env."GITHUB_CLIENT_ID", Figaro.env."GITHUB_CLIENT_SECERT", :scope => 'user,public_repo'
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or


### PR DESCRIPTION
nginx 跟 figaro 使用環境變數的方式相同，在設定檔裡面的環境變數，nginx 會誤認為是他的，所以改成 figaro 另外一種寫法，讓 nginx 不要誤會